### PR TITLE
Handle change a bit better

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -118,9 +118,10 @@ export default class Autocomplete extends Component {
 
   _onChange(e) {
     const value = e.target.value;
-    this.setState({ value, hoveredOptionIndex: null, selectedOption: null });
     this.props.onValueChange(value);
-    this._throttledUpdateOptions(value);
+    this.setState({ value, hoveredOptionIndex: null, selectedOption: null }, () => {
+      this._throttledUpdateOptions(value);
+    });
   }
 
   _onDocumentClick(e) {


### PR DESCRIPTION
Use the onValueChange a bit earlier, as it may cause a setState up the tree. The same way, we handle the update in the callback of the setState, to avoid race condition.